### PR TITLE
Loadbalancing: source ip affinity

### DIFF
--- a/roles/loadbalancer/templates/haproxy.cfg.j2
+++ b/roles/loadbalancer/templates/haproxy.cfg.j2
@@ -52,11 +52,11 @@ listen seahub-https :443
 backend seahub-backend
 {% if ssl_dec_loadbalancer %}
   redirect scheme https if !{ ssl_fc }
-  cookie SERVERID insert indirect nocache
 {% endif %}
   option forwardfor
+  balance source
   {% for node in groups['master'] + groups['clones'] %}
-  server seahubserver{{ loop.index }} {{ node }}:80 check port 11001{{ " cookie %s" % node if ssl_dec_loadbalancer else '' }}
+  server seahubserver{{ loop.index }} {{ node }}:80 check port 11001
   {% endfor %}
 
 listen monitor


### PR DESCRIPTION
Clients (tested desktop client) don't support cookies.
Use source ip affinity instead.
This works without decrypting traffic at loadbalancer, too.

Fixes #33.
