### PR TITLE
Support adjusting django/seahub throttling settings

### DIFF
--- a/roles/nodes/templates/seahub_settings.py.j2
+++ b/roles/nodes/templates/seahub_settings.py.j2
@@ -134,6 +134,17 @@ SHIBBOLETH_ATTRIBUTE_MAP = {
 ENABLE_SHIB_LOGIN = True
 {% endif %}
 
+{% if ping_throttle is defined or anon_throttle is defined or user_throttle is defined %}
+# rest_framwork
+REST_FRAMEWORK = {
+    'DEFAULT_THROTTLE_RATES': {
+        'ping': '{{ ping_throttle|default('600/minute') }}',
+        'anon': '{{ anon_throttle|default('5/minute') }}',
+        'user': '{{ user_throttle|default('300/minute') }}',
+    },
+}
+{% endif %}
+
 # settings new in 4.2
 SERVE_STATIC = False
 MEDIA_URL = '/media/'


### PR DESCRIPTION
Introduces 3 new variables: ping_throttle, anon_throttle and user_throttle.
If any of them are defined, insert throttling settings into seahub_settings.py.
All non-defined throttling settings use defaults extracted from seahub/settings.py.

Fixes #35.
